### PR TITLE
Minor updates to API docs

### DIFF
--- a/api-documentation/import.md
+++ b/api-documentation/import.md
@@ -203,3 +203,66 @@ Batch successfully transmitted.
 Ensure you have finished creating all Invoices for this Import before calling this method. It is not possible to change or add more Invoices to an Import after the Import has been transmitted. 
 {% endhint %}
 
+{% api-method method="delete" host="https://api.clubcollect.com/api" path="/v2/imports/:id" %}
+{% api-method-summary %}
+Delete Import
+{% endapi-method-summary %}
+
+{% api-method-description %}
+Deletes an import and all the invoices that have been created for the import.
+{% endapi-method-description %}
+
+{% api-method-spec %}
+{% api-method-request %}
+{% api-method-path-parameters %}
+{% api-method-parameter name="id" type="string" required=true %}
+Import ID
+{% endapi-method-parameter %}
+{% endapi-method-path-parameters %}
+
+{% api-method-query-parameters %}
+{% api-method-parameter name="api\_key" type="string" required=true %}
+Partner API Key
+{% endapi-method-parameter %}
+{% endapi-method-query-parameters %}
+{% endapi-method-request %}
+
+{% api-method-response %}
+{% api-method-response-example httpCode=204 %}
+{% api-method-response-example-description %}
+Batch successfully deleted.
+{% endapi-method-response-example-description %}
+
+```
+
+```
+{% endapi-method-response-example %}
+
+{% api-method-response-example httpCode=404 %}
+{% api-method-response-example-description %}
+
+{% endapi-method-response-example-description %}
+
+```javascript
+{
+  "error": "invalid_import_id"
+}
+```
+{% endapi-method-response-example %}
+
+{% api-method-response-example httpCode=422 %}
+{% api-method-response-example-description %}
+
+{% endapi-method-response-example-description %}
+
+```javascript
+{
+  "error": "import_already_transmitted"
+}
+```
+{% endapi-method-response-example %}
+{% endapi-method-response %}
+{% endapi-method-spec %}
+{% endapi-method %}
+
+

--- a/api-documentation/invoice.md
+++ b/api-documentation/invoice.md
@@ -603,7 +603,7 @@ Credit Invoice
 {% endapi-method-summary %}
 
 {% api-method-description %}
-Create a Credit Invoice for an existing Invoice. The Credit Invoice may contain one or more Invoice Lines. You cannot credit a Credit Invoice. Positive Invoice Line amounts are allowed provided the total amount is negative.
+Adds a credit to an existing Invoice. The credit may contain one or more Invoice Lines. You cannot credit an invoice that is fully credited or retracted. Positive Invoice Line amounts are allowed provided the total amount is negative and the total outstanding of the invoice is not negative after adding the invoice lines.
 {% endapi-method-description %}
 
 {% api-method-spec %}


### PR DESCRIPTION
A few days ago Cristian asked me about the invoices#credit method, he couldn't understand the description on the docs, i.e. it says we are creating a "credit invoice", which isn't happening, but the endpoint creates the invoice lines sent by the partner.

Also, after support requested a few times if we could delete batches for AllUnited, I realized that the `imports#destroy` method isn't in the API docs