### PR TITLE
Remove duplicate zipcode parameter

### DIFF
--- a/api-documentation/invoice.md
+++ b/api-documentation/invoice.md
@@ -258,10 +258,6 @@ Must be equal to the sum of the amounts of the Invoice Lines. May be zero or neg
 
 {% endapi-method-parameter %}
 
-{% api-method-parameter name="customer.address.zipcode" type="string" required=true %}
-
-{% endapi-method-parameter %}
-
 {% api-method-parameter name="customer.address.address1" type="string" required=true %}
 
 {% endapi-method-parameter %}


### PR DESCRIPTION
Remove duplicate `zipcode` parameter

![docs](https://user-images.githubusercontent.com/1447711/59851358-b815a000-9381-11e9-8757-4cecb5b482e3.png)
