### PR TITLE
Add payment_method field to Invoice JSON response

### DIFF
--- a/api-documentation/invoice-line.md
+++ b/api-documentation/invoice-line.md
@@ -65,7 +65,7 @@ Invoice Lines fetched successfully.
       "amount_cents": 123,            
       "description": null,            
       "date": "...",
-      "payment_method_code": "..."        
+      "payment_method": "..."        
     },        
     {          
       "invoice_line_id": "...",            
@@ -101,7 +101,7 @@ Invoice Lines fetched successfully.
       "amount_cents": 123,            
       "description": null,            
       "date": "...",
-      "payment_method_code": "..."        
+      "payment_method": "..."        
         
     },        
     {          
@@ -117,7 +117,7 @@ Invoice Lines fetched successfully.
         "amount_cents": 123,            
         "description": null,            
         "date": "...",        
-        "payment_method_code": "..."        
+        "payment_method": "..."        
         }    
       ],      
     "amount_total_cents": "..."
@@ -149,7 +149,7 @@ Invoice not found.
 {% endhint %}
 
 {% hint style="info" %}
-**Note** that `payment_method_code` is present only for Payment Lines and its value can be one of:
+**Note** that `payment_method` is present only for Payment Lines and its value can be one of:
 
 - `ideal`
 - `sdd`

--- a/api-documentation/invoice-line.md
+++ b/api-documentation/invoice-line.md
@@ -64,7 +64,8 @@ Invoice Lines fetched successfully.
       "type": "PAYMENT-LINE",           
       "amount_cents": 123,            
       "description": null,            
-      "date": "..."        
+      "date": "...",
+      "payment_method_code": "..."        
     },        
     {          
       "invoice_line_id": "...",            
@@ -99,7 +100,9 @@ Invoice Lines fetched successfully.
       "type": "LATE-PAYMENT-FEE-PAYMENT-LINE",            
       "amount_cents": 123,            
       "description": null,            
-      "date": "..."        
+      "date": "...",
+      "payment_method_code": "..."        
+        
     },        
     {          
       "invoice_line_id": "...",            
@@ -113,7 +116,8 @@ Invoice Lines fetched successfully.
         "type": "INSTALLMENT-FEE-PAYMENT-LINE",           
         "amount_cents": 123,            
         "description": null,            
-        "date": "..."        
+        "date": "...",        
+        "payment_method_code": "..."        
         }    
       ],      
     "amount_total_cents": "..."
@@ -144,3 +148,16 @@ Invoice not found.
 **Note** that `description` is not `null` only for regular Invoice Lines and Credit Lines.
 {% endhint %}
 
+{% hint style="info" %}
+**Note** that `payment_method_code` is present only for Payment Lines and its value can be one of:
+
+- `ideal`
+- `sdd`
+- `bank_transfer`
+- `credit_card`
+- `bancontact`
+- `bacs`
+- `sofort`
+- `external`
+
+{% endhint %}


### PR DESCRIPTION
updates Invoice Line API docs with `payment_method_code` field which is going to be added soon.