### PR TITLE
Remove deprecated cbio_trial flag

### DIFF
--- a/api-documentation/company.md
+++ b/api-documentation/company.md
@@ -93,10 +93,6 @@ Partner API Key.
 Name of Company.
 {% endapi-method-parameter %}
 
-{% api-method-parameter name="cbio\_trial" type="boolean" required=true %}
-When `true`, some mandatory parameters become optional.
-{% endapi-method-parameter %}
-
 {% api-method-parameter name="brand" type="string" required=true %}
 Brand code. From `{ clubbaseio knltb dtb clubcollect clubcollectde }`.
 {% endapi-method-parameter %}


### PR DESCRIPTION
`cbio_trial` flag for Company API is deprecated and should be removed.