### PR TITLE
Rephrase api_key information text

### DIFF
--- a/api-documentation/notifications.md
+++ b/api-documentation/notifications.md
@@ -23,7 +23,7 @@ The format of the request body is as follows:
 ```
 
 {% hint style="info" %}
-The provision of `api_key` is a means of verifying that the request originated from ClubCollect.
+The `api_key` is provided in the request body so that you can verify that the request comes from ClubCollect.
 {% endhint %}
 
 Using both the `invoice_ids` array and the `import_ids` array allows the Partner to fetch invoices and imports respectively via the relevant API endpoints to pull through the latest information. For example, after receiving the request body from the example above, four API calls could be made to fetch data on three invoices and one import.


### PR DESCRIPTION
Notifications API doc contains information describing the reason for `api_key` presence in JSON response. New form should be easier to understand for non-native English speakers (-: