### PR TITLE
Add missing info for customer address fields

### DIFF
--- a/api-documentation/invoice.md
+++ b/api-documentation/invoice.md
@@ -257,27 +257,47 @@ Must be equal to the sum of the amounts of the Invoice Lines. May be zero or neg
 {% endapi-method-parameter %}
 
 {% api-method-parameter name="customer.address.city" type="string" required=true %}
-
+May be empty if \`email\_address\` or \`phone\_number\` is provided\`
 {% endapi-method-parameter %}
 
 {% api-method-parameter name="customer.address.zipcode" type="string" required=true %}
-
+May be empty if \`email\_address\` or \`phone\_number\` is provided\`
 {% endapi-method-parameter %}
 
 {% api-method-parameter name="customer.address.address1" type="string" required=true %}
+May be empty if \`email\_address\` or \`phone\_number\` is provided\`
+{% endapi-method-parameter %}
+
+{% api-method-parameter name="customer.address.address2" type="string" required=false %}
+
+{% endapi-method-parameter %}
+
+{% api-method-parameter name="customer.address.house_number" type="string" required=false %}
+
+{% endapi-method-parameter %}
+
+{% api-method-parameter name="customer.address.house_number_extension" type="string" required=false %}
+
+{% endapi-method-parameter %}
+
+{% api-method-parameter name="customer.address.locality" type="string" required=false %}
+
+{% endapi-method-parameter %}
+
+{% api-method-parameter name="customer.address.state" type="string" required=false %}
 
 {% endapi-method-parameter %}
 
 {% api-method-parameter name="customer.phone.country\_code" type="string" required=true %}
-May be empty if \`email\_address\` is provided\`
+May be empty if \`email\_address\` or a postal address is provided\`
 {% endapi-method-parameter %}
 
 {% api-method-parameter name="customer.phone.phone\_number" type="string" required=true %}
-May be empty if \`email\_address\` is provided.
+May be empty if \`email\_address\` or a postal address is provided.
 {% endapi-method-parameter %}
 
 {% api-method-parameter name="customer.email.email\_address" type="string" required=true %}
-May be empty if \`phone\_number\` is provided.
+May be empty if \`phone\_number\` or a postal address is provided.
 {% endapi-method-parameter %}
 
 {% api-method-parameter name="customer.name.last\_name" type="string" required=true %}


### PR DESCRIPTION
Ref conversation started on slack, it might not be clear on the API docs which customer fields are actually required.