### PR TITLE
Remove unused Tickets page

### DIFF
--- a/api-documentation/tickets.md
+++ b/api-documentation/tickets.md
@@ -1,8 +1,0 @@
----
-description: 'Manage Tickets, customer communication relating to individual Invoices.'
----
-
-# Tickets
-
-
-


### PR DESCRIPTION
No associated Issue.

I spotted an `Untitled` heading in the API documentation linking to an empty page. 

<img width="219" alt="Partnering with ClubCollect - ClubCollect 2020-01-15 10-03-20" src="https://user-images.githubusercontent.com/35313/72420169-84b3bc00-377e-11ea-9e69-ad3efe59f2de.png">

On reviewing the pages in the Git repository I came across `tickets.md` which is unused. 

I’m not sure whether or not this will solve the issue, but it is a sensible step to clean up. There is a separate page for Tickets (`ticket.md`)