### PR TITLE
Add prefix, first_name and infix to create invoice docu

### DIFF
--- a/api-documentation/invoice.md
+++ b/api-documentation/invoice.md
@@ -332,12 +332,19 @@ May be empty if \`email\_address\` or a postal address is provided
 May be empty if \`phone\_number\` or a postal address is provided
 {% endapi-method-parameter %}
 
-{% api-method-parameter name="customer.name.last\_name" type="string" required=true %}
+{% api-method-parameter name="customer.name.prefix" type="string" required=false %}
+{% endapi-method-parameter %}
 
+{% api-method-parameter name="customer.name.first\_name" type="string" required=false %}
+{% endapi-method-parameter %}
+
+{% api-method-parameter name="customer.name.infix" type="string" required=false %}
+{% endapi-method-parameter %}
+
+{% api-method-parameter name="customer.name.last\_name" type="string" required=true %}
 {% endapi-method-parameter %}
 
 {% api-method-parameter name="customer.name.organization" type="string" required=false %}
-
 {% endapi-method-parameter %}
 
 {% api-method-parameter name="external\_invoice\_number" type="string" required=true %}


### PR DESCRIPTION
> I see that `customer.name.prefix` is not listed in the "Body Parameters" section in https://docs.clubcollect.com/api-documentation/invoice#create-invoice but it is shown in the "Example Body Request" and we also use it in CB. The same is with `first_name` and `infix`. I think this should be fixed.
—https://clubcollect.slack.com/archives/C3ANH5UVA/p1621424948007900