### PR TITLE
Use canonical URL for API endpoint

### DIFF
--- a/api-documentation/company.md
+++ b/api-documentation/company.md
@@ -8,7 +8,7 @@ description: 'Manage Companies, the entity representing an individual organisati
 This endpoint is not yet operational and is thus subject to change.
 {% endhint %}
 
-{% api-method method="get" host="https://api.clubcollect.com/api" path="/v2/companies/:id" %}
+{% api-method method="get" host="https://app.clubcollect.com/api" path="/v2/companies/:id" %}
 {% api-method-summary %}
 Show Company
 {% endapi-method-summary %}
@@ -77,7 +77,7 @@ Could not find a Company with this ID.
 {% endapi-method-spec %}
 {% endapi-method %}
 
-{% api-method method="post" host="https://api.clubcollect.com/api" path="/v2/companies" %}
+{% api-method method="post" host="https://app.clubcollect.com/api" path="/v2/companies" %}
 {% api-method-summary %}
 Create Company
 {% endapi-method-summary %}
@@ -182,7 +182,7 @@ Company successfully created.
 {% endapi-method-spec %}
 {% endapi-method %}
 
-{% api-method method="put" host="https://api.clubcollect.com/api" path="/v2/companies/:id" %}
+{% api-method method="put" host="https://app.clubcollect.com/api" path="/v2/companies/:id" %}
 {% api-method-summary %}
 Update Company
 {% endapi-method-summary %}

--- a/api-documentation/import.md
+++ b/api-documentation/import.md
@@ -4,7 +4,7 @@ description: 'Manage Imports, which are collections of Invoices.'
 
 # Import
 
-{% api-method method="get" host="https://api.clubcollect.com/api" path="/v2/imports/:id" %}
+{% api-method method="get" host="https://app.clubcollect.com/api" path="/v2/imports/:id" %}
 {% api-method-summary %}
 Show Import
 {% endapi-method-summary %}
@@ -75,7 +75,7 @@ Could not find an Import with this ID.
 {% endapi-method-spec %}
 {% endapi-method %}
 
-{% api-method method="post" host="https://api.clubcollect.com/api" path="/v2/imports" %}
+{% api-method method="post" host="https://app.clubcollect.com/api" path="/v2/imports" %}
 {% api-method-summary %}
 Create Import
 {% endapi-method-summary %}
@@ -158,7 +158,7 @@ are created.
 The following `/imports/:id/transmit` endpoint will be deprecated soon in favour of manually transmitting an Import via the ClubCollect User Interface. This gives treasurers the opportunity to configure settings correctly which is not possible via the API.
 {% endhint %}
 
-{% api-method method="put" host="https://api.clubcollect.com/api" path="/v2/imports/:id/transmit" %}
+{% api-method method="put" host="https://app.clubcollect.com/api" path="/v2/imports/:id/transmit" %}
 {% api-method-summary %}
 Transmit Import
 {% endapi-method-summary %}
@@ -242,7 +242,7 @@ Batch successfully transmitted.
 Ensure you have finished creating all Invoices for this Import before calling this method. It is not possible to change or add more Invoices to an Import after the Import has been transmitted.
 {% endhint %}
 
-{% api-method method="put" host="https://api.clubcollect.com/api" path="/v2/imports/:id" %}
+{% api-method method="put" host="https://app.clubcollect.com/api" path="/v2/imports/:id" %}
 {% api-method-summary %}
 Update Import
 {% endapi-method-summary %}
@@ -343,7 +343,7 @@ are created.
 {% endapi-method-spec %}
 {% endapi-method %}
 
-{% api-method method="delete" host="https://api.clubcollect.com/api" path="/v2/imports/:id" %}
+{% api-method method="delete" host="https://app.clubcollect.com/api" path="/v2/imports/:id" %}
 {% api-method-summary %}
 Delete Import
 {% endapi-method-summary %}
@@ -411,7 +411,7 @@ Batch successfully deleted.
 {% endapi-method-spec %}
 {% endapi-method %}
 
-{% api-method method="get" host="https://api.clubcollect.com/api" path="/v2/companies/:id/imports" %}
+{% api-method method="get" host="https://app.clubcollect.com/api" path="/v2/companies/:id/imports" %}
 {% api-method-summary %}
 Fetch Company Imports
 {% endapi-method-summary %}

--- a/api-documentation/invoice-line.md
+++ b/api-documentation/invoice-line.md
@@ -4,7 +4,7 @@ description: Manage Invoice Line Items.
 
 # Invoice Line
 
-{% api-method method="get" host="https://api.clubcollect.com/api" path="/v2/invoices/:id/lines" %}
+{% api-method method="get" host="https://app.clubcollect.com/api" path="/v2/invoices/:id/lines" %}
 {% api-method-summary %}
 Fetch Invoice Lines
 {% endapi-method-summary %}

--- a/api-documentation/invoice.md
+++ b/api-documentation/invoice.md
@@ -4,7 +4,7 @@ description: Manage Invoices.
 
 # Invoice
 
-{% api-method method="get" host="https://api.clubcollect.com/api" path="/v2/invoices/:id" %}
+{% api-method method="get" host="https://app.clubcollect.com/api" path="/v2/invoices/:id" %}
 {% api-method-summary %}
 Show Invoice
 {% endapi-method-summary %}
@@ -220,7 +220,7 @@ Partner API Key (Deprecated)
 {% endhint %}
 
 
-{% api-method method="post" host="https://api.clubcollect.com/api" path="/v2/invoices" %}
+{% api-method method="post" host="https://app.clubcollect.com/api" path="/v2/invoices" %}
 {% api-method-summary %}
 Create Invoice
 {% endapi-method-summary %}
@@ -517,7 +517,7 @@ must be provided. i.e. there must be a way for us to contact the Customer via em
 **Note** It's not possible to add or delete invoice lines for an existing invoice. If an invoice is incorrectly created with a wrong amount outstanding (or the invoice becomes invalid for some reason after it's transmitted), the partner can credit it using `/credit_and_retract` endpoint.
 {% endhint %}
 
-{% api-method method="put" host="https://api.clubcollect.com/api" path="/v2/invoices/:id" %}
+{% api-method method="put" host="https://app.clubcollect.com/api" path="/v2/invoices/:id" %}
 {% api-method-summary %}
 Update Invoice
 {% endapi-method-summary %}
@@ -788,7 +788,7 @@ When supplied, will be accepted and added to the Invoice only if it is a valid I
 * `invalid_customer_phone`: Phone number may not be empty if no email address is provided.
 * `invalid_content_type`: `Content-Type: application/json` must be provided.
 
-{% api-method method="post" host="https://api.clubcollect.com/api" path="/v2/invoices/:id/credit\_and\_retract" %}
+{% api-method method="post" host="https://app.clubcollect.com/api" path="/v2/invoices/:id/credit\_and\_retract" %}
 {% api-method-summary %}
 Credit and Retract Invoice
 {% endapi-method-summary %}
@@ -953,7 +953,7 @@ Partner API Key (Deprecated)
 * `invalid_content_type`: `Content-Type: application/json` must be provided.
 * `payment_in_progress`: An invoice can't be credited or retracted if there's a payment in progress
 
-{% api-method method="delete" host="https://api.clubcollect.com/api" path="/v2/invoices/:id" %}
+{% api-method method="delete" host="https://app.clubcollect.com/api" path="/v2/invoices/:id" %}
 {% api-method-summary %}
 Delete Invoice
 {% endapi-method-summary %}

--- a/api-documentation/ticket.md
+++ b/api-documentation/ticket.md
@@ -1,6 +1,6 @@
 # Ticket
 
-{% api-method method="get" host="https://api.clubcollect.com/api" path="/v2/invoices/:id/tickets" %}
+{% api-method method="get" host="https://app.clubcollect.com/api" path="/v2/invoices/:id/tickets" %}
 {% api-method-summary %}
 Fetch Tickets
 {% endapi-method-summary %}
@@ -73,7 +73,7 @@ Partner API Key (Deprecated)
 {% endapi-method-spec %}
 {% endapi-method %}
 
-{% api-method method="post" host="https://api.clubcollect.com/api" path="/v2/invoices/:id/tickets" %}
+{% api-method method="post" host="https://app.clubcollect.com/api" path="/v2/invoices/:id/tickets" %}
 {% api-method-summary %}
 Create Ticket
 {% endapi-method-summary %}
@@ -155,7 +155,7 @@ Invoice not found.
 {% endapi-method-spec %}
 {% endapi-method %}
 
-{% api-method method="post" host="https://api.clubcollect.com/api" path="/v2/invoices/:id/tickets/actions/archive" %}
+{% api-method method="post" host="https://app.clubcollect.com/api" path="/v2/invoices/:id/tickets/actions/archive" %}
 {% api-method-summary %}
 Archive Ticket
 {% endapi-method-summary %}
@@ -215,7 +215,7 @@ Partner API Key (Deprecated)
 {% endapi-method-spec %}
 {% endapi-method %}
 
-{% api-method method="post" host="https://api.clubcollect.com/api" path="/v2/invoices/:id/tickets/actions/assign\_to\_support" %}
+{% api-method method="post" host="https://app.clubcollect.com/api" path="/v2/invoices/:id/tickets/actions/assign\_to\_support" %}
 {% api-method-summary %}
 Assign Ticket to Support
 {% endapi-method-summary %}
@@ -275,7 +275,7 @@ Partner API Key (Deprecated)
 {% endapi-method-spec %}
 {% endapi-method %}
 
-{% api-method method="get" host="https://api.clubcollect.com/api" path="/v2/companies/:id/tickets/:status" %}
+{% api-method method="get" host="https://app.clubcollect.com/api" path="/v2/companies/:id/tickets/:status" %}
 {% api-method-summary %}
 Fetch All Tickets
 {% endapi-method-summary %}


### PR DESCRIPTION
No associated issue.

Remove the `api` domain alias to enable a web application firewall.
